### PR TITLE
[Bootloader] Slow down display thread during .bin upload

### DIFF
--- a/pyluos/tools/bootloader.py
+++ b/pyluos/tools/bootloader.py
@@ -157,34 +157,32 @@ def send_ready_cmd(device, node):
 # @return binary size
 # *******************************************************************************
 def waiting_erase():
-    init_time = time.time()
     count = 0
     period = 0.4
     print("\r                        ", end='')
     print("\r  ╰> Erase flash        ", end='')
     while(1):
-        if(time.time() - init_time > period):
-            init_time = time.time()
-            if(count == 0):
-                print("\r                        ", end='')
-                print("\r  ╰> Erase flash .      ", end='')
-                count += 1
-                continue
-            if(count == 1):
-                print("\r                        ", end='')
-                print("\r  ╰> Erase flash ..     ", end='')
-                count += 1
-                continue
-            if(count == 2):
-                print("\r                        ", end='')
-                print("\r  ╰> Erase flash ...    ", end='')
-                count += 1
-                continue
-            if(count == 3):
-                print("\r                        ", end='')
-                print("\r  ╰> Erase flash        ", end='')
-                count = 0
-                continue
+        time.sleep(period)
+        if(count == 0):
+            print("\r                        ", end='')
+            print("\r  ╰> Erase flash .      ", end='')
+            count += 1
+            continue
+        if(count == 1):
+            print("\r                        ", end='')
+            print("\r  ╰> Erase flash ..     ", end='')
+            count += 1
+            continue
+        if(count == 2):
+            print("\r                        ", end='')
+            print("\r  ╰> Erase flash ...    ", end='')
+            count += 1
+            continue
+        if(count == 3):
+            print("\r                        ", end='')
+            print("\r  ╰> Erase flash        ", end='')
+            count = 0
+            continue
 
 # *******************************************************************************
 # @brief send erase command

--- a/pyluos/tools/bootloader.py
+++ b/pyluos/tools/bootloader.py
@@ -223,12 +223,10 @@ def erase_flash(device, node):
 # @return binary size
 # *******************************************************************************
 def loading_bar(loading_progress):
-    init_time = time.time()
     period = 0.2
     while(1):
-        if(time.time() - init_time > period):
-            init_time = time.time()
-            print("\r  ╰> loading : {} %".format(loading_progress.value), end='')
+        time.sleep(period)
+        print("\r  ╰> loading : {} %".format(loading_progress.value), end='')
 
 # *******************************************************************************
 # @brief send the binary file to the node


### PR DESCRIPTION
**/!\ This is the correct PR, I messed up the previous one**

The background thread for displaying the progress was using a lot of CPU for nothing, so I propose this fix to slow it down and prevent my laptop's fan from going crazy!