### PR TITLE
Close Device at the end of luos_reset

### DIFF
--- a/pyluos/tools/bootloader.py
+++ b/pyluos/tools/bootloader.py
@@ -597,6 +597,9 @@ def luos_reset(args):
     # detect network
     device = Device(args.port, background_task=False)
     print(device.nodes)
+    device.close()
+
+    return BOOTLOADER_SUCCESS
 
 # *******************************************************************************
 # @brief command used to detect network


### PR DESCRIPTION
This is required for using the bootloader tools from Python scripts and not from the CLI.