### PR TITLE
Improve statistics handling

### DIFF
--- a/pyluos/services/service.py
+++ b/pyluos/services/service.py
@@ -117,9 +117,9 @@ class Service(object):
             s = s + "\n.Max luos loop delay \t\t= " + repr(self._luos_statistics["loop_ms"])
             s = s + "ms\n.msg max retry number \t\t= " + repr(self._luos_statistics["max_retry"])
             s = s + "\n"
-            print(s)
+            return self._luos_statistics
         except:
-            print(self.alias + " statistics collection failed.\n")
+            return None
 
     def rename(self, name):
         # check if the string start with a number before sending

--- a/pyluos/services/service.py
+++ b/pyluos/services/service.py
@@ -103,8 +103,15 @@ class Service(object):
 
     @property
     def luos_statistics(self):
+        """Get service statistics with a timeout of 1 second."""
+
+        self._luos_statistics = None
         self._push_value('luos_statistics', "")
-        time.sleep(0.3)
+
+        tick_start = time.time()
+        while time.time() - tick_start < 1 and self._luos_statistics is None:
+            time.sleep(0.01)
+
         try:
             max_table = [self._luos_statistics["rx_msg_stack"], self._luos_statistics["luos_stack"], self._luos_statistics["tx_msg_stack"], self._luos_statistics["buffer_occupation"]]
             max_val = max(max_table)

--- a/pyluos/services/service.py
+++ b/pyluos/services/service.py
@@ -62,6 +62,7 @@ class Service(object):
             self._uuid = new_state['uuid']
         if 'luos_statistics' in new_state:
             self._luos_statistics = new_state['luos_statistics']
+            self._luos_statistics['alias'] = self.alias
 
     def _kill(self):
         self._killed = True


### PR DESCRIPTION
I propose to:

1. add the alias of the service among its statistics. This makes it easier to process a lot of statistics automatically.
1. actually return the statistics in the `luos_statistics` getter. It is the expected behavior of a getter in my opinion.