### PR TITLE
Improve time management when retrieving services metadata

### DIFF
--- a/pyluos/services/service.py
+++ b/pyluos/services/service.py
@@ -19,6 +19,7 @@ except ImportError:
 
 Event = namedtuple('Event', ('name', 'old_value', 'new_value'))
 
+READ_TIMEOUT = 0.3
 
 class Service(object):
     possible_events = set()
@@ -88,7 +89,7 @@ class Service(object):
         self._push_value('revision', "")
 
         tick_start = time.time()
-        while time.time() - tick_start < 1 and self._firmware_revision is None:
+        while time.time() - tick_start < READ_TIMEOUT and self._firmware_revision is None:
             time.sleep(0.01)
 
         return self._firmware_revision
@@ -99,7 +100,7 @@ class Service(object):
         self._push_value('luos_revision', "")
 
         tick_start = time.time()
-        while time.time() - tick_start < 1 and self._luos_revision is None:
+        while time.time() - tick_start < READ_TIMEOUT and self._luos_revision is None:
             time.sleep(0.01)
 
         return self._luos_revision
@@ -110,7 +111,7 @@ class Service(object):
         self._push_value('uuid', "")
 
         tick_start = time.time()
-        while time.time() - tick_start < 1 and self._uuid is None:
+        while time.time() - tick_start < READ_TIMEOUT and self._uuid is None:
             time.sleep(0.01)
 
         return self._uuid

--- a/pyluos/services/service.py
+++ b/pyluos/services/service.py
@@ -84,20 +84,35 @@ class Service(object):
 
     @property
     def firmware_revision(self):
+        self._firmware_revision = None
         self._push_value('revision', "")
-        time.sleep(0.03)
+
+        tick_start = time.time()
+        while time.time() - tick_start < 1 and self._firmware_revision is None:
+            time.sleep(0.01)
+
         return self._firmware_revision
 
     @property
     def luos_revision(self):
+        self._luos_revision = None
         self._push_value('luos_revision', "")
-        time.sleep(0.03)
+
+        tick_start = time.time()
+        while time.time() - tick_start < 1 and self._luos_revision is None:
+            time.sleep(0.01)
+
         return self._luos_revision
 
     @property
     def uuid(self):
+        self._uuid = None
         self._push_value('uuid', "")
-        time.sleep(0.03)
+
+        tick_start = time.time()
+        while time.time() - tick_start < 1 and self._uuid is None:
+            time.sleep(0.01)
+
         return self._uuid
 
     @property


### PR DESCRIPTION
PyLuos blindly waits a fixed amount of time after asking for `luos_revision`, `firmware_revision`, and `uuid`.

In this PR, I propose a new method to return the requested value as soon as it is available. This tends to improve reliability of `luos_revision`, `firmware_revision`, and `uuid` readings.

In a way, it is related to 
- https://github.com/Luos-io/Pyluos/issues/141
- https://github.com/Luos-io/Pyluos/pull/151