### PR TITLE
Fix JSON key for translational speed

### DIFF
--- a/pyluos/services/unknown.py
+++ b/pyluos/services/unknown.py
@@ -134,7 +134,7 @@ class Unknown(Service):
     @angular_speed.setter
     def translation_speed(self, s):
         self._angular_speed = s
-        self._push_value("target_rot_speed", s)
+        self._push_value("target_trans_speed", s)
 
     @property
     def current(self):


### PR DESCRIPTION
There is a typo in _unknown.py_.